### PR TITLE
AO-739: removed transifex-client, installed transifex CLI API v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /root
 # NOTE bzip2 is required by PhantomJS-prebuilt
 # NOTE buildessential is needed for node-sass (installed by gulp-sass)
 RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
-RUN apt-get update && apt-get install -y bash build-essential libfontconfig transifex-client git curl bzip2
+RUN apt-get update && apt-get install -y bash build-essential libfontconfig git curl bzip2
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 RUN apt-get install -t stretch-backports openjdk-8-jre-headless ca-certificates-java -y
 
 # Download Chrome dependencies

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Passing flags in with the grunt command will overwrite base options set within.
 - `--serve` will run the development server along with any other command (and will keep the process alive). When this command is used, any URL configurations that start with `http` will be replaced with a proxy URL which will add CORS headers to the actual requested URL.
 - `--pullTransifex` causes the `grunt messages` command to attempt to pull locale specific message files from Transifex for the current directory. The sync will only occur if:
 -- A valid `transifexProject` name is defined in the `project.properties` file
--- A transifex username and password are supplied either as environment variables (`TRANSIFEX_USER`, `TRANSIFEX_PASSWORD`)
+-- A transifex token is supplied as environment variables (`TX_TOKEN`) (Changed into this mechanism due to migration of transifex CLI for having compatibility with the newest version of API) 
 - `--pushTransifex` makes `grunt messages` command push the translations to Transifex. Should be used in combination with `--pullTransifex`.
 
 ### Proxy URLs

--- a/tasks/messages.js
+++ b/tasks/messages.js
@@ -78,8 +78,7 @@ module.exports = function(grunt){
      * Updates current app's merged message file to transifex.
      */
     grunt.registerTask('messages:transifex', function(){
-        var transifexUser = process.env.TRANSIFEX_USER,
-            transifexPassword = process.env.TRANSIFEX_PASSWORD,
+        var transifexApiToken = process.env.TX_TOKEN,
             projectProperties = properties.read('project.properties'),
             transifexProject = projectProperties.transifexProject;
 
@@ -87,8 +86,8 @@ module.exports = function(grunt){
             return;
         }
 
-        if(!transifexUser || !transifexPassword){
-            console.log('- no transifex user or password, skipping');
+        if(!transifexApiToken){
+            console.log('- no transifex token, skipping');
             return ;
         }
 
@@ -114,12 +113,18 @@ module.exports = function(grunt){
 
         var commands = [
             "rm -rf .tx",
-            "tx init --host=https://www.transifex.com --user=" + transifexUser + " --pass=" + transifexPassword,
-            "tx set --auto-local -r " + transifexProject + ".messages '" + filePattern
-            + "' --source-lang en --type KEYVALUEJSON --source-file " + sourceFile + " --execute",
+            "tx init",
+            "tx add " 
+              + "--file-filter='" + filePattern + "' "
+              + "--type=KEYVALUEJSON "
+              + "--organization=openlmis "
+              + "--project=" + transifexProject + " "
+              + "--resource=messages "
+              + sourceFile,
             "tx push -s",
             "tx pull -a -f"
         ];
+        
         if(!grunt.option('pushTransifex')) {
             commands.splice(3, 1);
         }


### PR DESCRIPTION
TICKET: https://openlmis.atlassian.net/browse/AO-739

- removed transifex-client due to incompatibility with the newest API (API v2 stopped working few days ago)
- added transifex CLI library written in Go to have compatibility with the newest version of API (API v3)
- added reading TX_TOKEN variable from env
- Transifex username and password are no more used in new CLI therefore those env are removed from job. 