### PR TITLE
OIS-20: add missing stylelint-rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY .htmlhintrc .
 COPY .sass-lint.yml .
 COPY .stylelintrc .
 
+# Linter Custom Rules
+COPY stylelint-rules ./stylelint-rules
+
 # Build process
 COPY sonar.sh .
 COPY build.sh .


### PR DESCRIPTION
Add missing **COPY stylelint-rules ./stylelint-rules** to the Dockerfile