### PR TITLE
OIS-21: added supported RTL languages property.

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,5 +21,6 @@
     "title": "OpenLMIS-UI Documentation"
   },
   "applicationTitle": "OpenLMIS",
-  "defaultLanguage": "en"
+  "defaultLanguage": "en",
+  "supportedRTLLanguages": ["pt"]
 }


### PR DESCRIPTION
OIS-21: added supported RTL languages property. For now with test value of Portuguese

ticket: https://openlmis.atlassian.net/browse/OIS-21