### PR TITLE
OIS-22: set page dir based on language

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,5 +22,5 @@
   },
   "applicationTitle": "OpenLMIS",
   "defaultLanguage": "en",
-  "supportedRTLLanguages": ["pt"]
+  "supportedRTLLanguages": []
 }

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,22 @@
         <script type="text/javascript" src="openlmis.js" async="true"></script>
         <link rel="manifest" href="manifest.json" />
     </head>
-    <body >
+    <body>
+        <div style="display: none;" id="rtlLanguagesDiv">@@SUPPORTED_RTL_LANGUAGES</div>
         <div ui-view></div>
+        <script>
+             function setPageDirection() {
+                const rtlLanguagesDiv = document.getElementById('rtlLanguagesDiv');
+                const rtlLanguages = rtlLanguagesDiv.innerText.split(',');
+                const currrentLanguage = localStorage.getItem('openlmis.current_locale');
+                let pageDirection = 'ltr'
+                if (currrentLanguage && rtlLanguages.includes(currrentLanguage)) {
+                    pageDirection = 'rtl';
+                }
+
+                document.documentElement.setAttribute('dir', pageDirection);
+            }
+            setPageDirection();
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Resolving ticket: https://openlmis.atlassian.net/browse/OIS-22
When user changes a language to the one placed in the file config.json in supportedRTLLanguages the page will change dir to "rtl"