### PR TITLE
OIS-28: delete pt from RTL languagues, add arabic

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,5 +22,5 @@
   },
   "applicationTitle": "OpenLMIS",
   "defaultLanguage": "en",
-  "supportedRTLLanguages": ["pt"]
+  "supportedRTLLanguages": ["ar"]
 }


### PR DESCRIPTION
[OIS-28](https://openlmis.atlassian.net/browse/OIS-28)

Changes:
- Remove `pt` language from RTL supported.
- Add arabic.

[OIS-28]: https://openlmis.atlassian.net/browse/OIS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ