### PR TITLE
OE-138: lock global _ to Underscore to prevent Lodash override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 WORKDIR /root
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,13 @@ window.$ = require('jquery');
 window.jquery = window.$;
 window.jQuery = window.$;
 
-window._ = require('underscore');
+Object.defineProperty(window, '_', {
+  value: require('underscore'),
+  writable: false,
+  configurable: false
+});
 
 require('./vendors');
-
 require('./app');
 require('./bundle');
 


### PR DESCRIPTION
[OE-138](https://openlmis.atlassian.net/browse/OE-138)

Issue: The issue arises because the global _ variable (initially set to Underscore) is later overridden by Lodash, causing functions like _.pluck or _.contains to disappear.

Fix: Lock global `_` to Underscore to prevent Lodash override.

[OE-138]: https://openlmis.atlassian.net/browse/OE-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ